### PR TITLE
Include Skate AVS

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ This is by no means an exhaustive list or an endorsement. It's a set of projects
   - [Repo](https://github.com/witnesschain-com/diligencewatchtower-contracts)
   - [Architecture](https://docs.witnesschain.com/diligence-watchtowers/watchtower-protocol-version-2/watchtower-architecture)
   - [Operator intake link](https://discord.gg/ZwdnTBAtqV)
+- [Skate](https://skatechain.org/)
+  - The only universal application layer that empowers apps to run on 1000s of chains with one state.
+  - [Repo](https://github.com/Skate-Org/AVS)
+  - [Docs](https://docs.skatechain.org/)
 
 ### 👥 Community
 


### PR DESCRIPTION
Website: https://www.skatechain.org/
Twitter: https://twitter.com/skate_chain