### PR TITLE
add u--1 to the analytics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 ### 📊 Data & Analytics
 
 - [EigenExplorer API](https://docs.eigenexplorer.com/api-reference/introduction)
+- [u--1 dashboard](https://u--1.com)
 
 
 ## AVS


### PR DESCRIPTION
Hi there,

[u--1](https://u--1.com) is an independent dashboard built for the EigenLayer ecosystem showing AVSs, LRTs and operators. Our dashboard is purpose built to be accessible and reliable, and all our data is made available in a free API. 

I've created this PR to add _u--1_ to the analytics section in the README - hope you agree it would fit well.

You can also find a few mentions from our users below:

https://x.com/DougieDeLuca/status/1786017509985992997
https://x.com/RenzoProtocol/status/1788655475904450652
https://x.com/tokensightxyz/status/1798014407576076692